### PR TITLE
GitHub Actionsを複数同時に実行できないように

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+concurrency:
+  group: terraform
+
 jobs:
   apply:
     runs-on: ubuntu-latest

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -10,6 +10,9 @@ permissions:
   pull-requests: write
   contents: read
 
+concurrency:
+  group: terraform
+
 jobs:
   plan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Terraformがlockをとっているので、Actionが走っているときに他のActionが開始すると失敗する。
```yml
concurrency:
  group: terraform
```
この設定で、
> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled. 

らしい。最後の一文によればpendingになっているものがある状態でさらにpendingが来ると古いのはキャンセルされちゃうらしいけど、競合して変な挙動するよりはいいと思う