### PR TITLE
Add team hackathon_24_spring and h24s_17

### DIFF
--- a/hackathon/h24s.tf
+++ b/hackathon/h24s.tf
@@ -1,0 +1,36 @@
+module "h24s_parent_team" {
+  source = "../modules/teams"
+
+  team_name   = "hackathon_24_spring"
+  members     = local.h24s_parent.members
+  maintainers = local.h24s_parent.maintainers
+  description = "2024春ハッカソン"
+}
+
+module "h24s_children_teams" {
+  for_each = local.h24s_children
+  source   = "../modules/teams"
+
+  team_name   = each.key
+  members     = each.value.members
+  maintainers = each.value.maintainers
+  description = contains(keys(each.value), "description") ? each.value.description : ""
+
+  parent_id = module.h24s_parent_team.team_id
+}
+
+locals {
+  h24s_parent = {
+    members = [
+      "ErrorSyntax1", "Liscome", "H1rono", "itt828", "PL-38"
+    ]
+    maintainers = ["Takeno-hito", "kaitoyama", "H1rono", "ikura-hamu"]
+  }
+
+  h24s_children = {
+    "h24s_17" = {
+      members     = ["ErrorSyntax1", "Liscome", "PL-38"]
+      maintainers = ["itt828", "H1rono"]
+    }
+  }
+}

--- a/members.tf
+++ b/members.tf
@@ -40,6 +40,7 @@ locals {
     "kenken714",
     "kisepichu",
     "Kuryu025",
+    "Liscome", # Liscome
     "Luftalian",
     "mathsuky",
     "mehm8128",
@@ -54,6 +55,7 @@ locals {
     "penguin23-001",
     "pikachu0310",
     "pirosiki197",
+    "PL-38", # PL-38
     "Pugma",
     "ramdos0207",
     "ras0q",


### PR DESCRIPTION
# traP-jp members Pull Request

## この変更の目的

ハッカソンのため

## GitHub IDとtraQ IDの対応

<!--例:
| GitHub ID | traQ ID |
| --------- | ------- |
| @ikura-hamu | ikura-hamu |
| @H1rono | H1rono_K |
-->

| GitHub ID | traQ ID |
| --------- | ------- |
| @ErrorSyntax1 | SyntaxError |
| @itt828   | itt     |
| @H1rono   | H1rono  |
| @Liscome  | Liscome |
| @PL-38    | PL-38   |


## 備考

## 加えた変更で、IDにtypoが無いことを確認しましたか?

**typoした先が実在するIDだった場合、無関係な人にtraP-jpへの招待が飛ぶなどの可能性があります。**

- [x] 確認した
