### PR TITLE
stam, wakky を github-org と h24s-18 に追加

### DIFF
--- a/hackathon/h24s.tf
+++ b/hackathon/h24s.tf
@@ -29,6 +29,7 @@ locals {
       "Pentakon26", "pippi0057", "pirosiki197", "PL-38", "Pugma", "reiroop", "riku6174", "Series-205",
       "Synori", "trasta298", "ultsaza", "zer0-star", "aya-se", "shushuya0210", "mumumu6",
       "ZOI-dayo", "yuhima03", "cp-20", "AlteraKlam", "Propromp", "ynta-3", "shibutomo", "Silent-Clubstep", "comavius",
+      "stamtam", "alcedo-taku"
     ]
     maintainers = ["Takeno-hito", "kaitoyama", "H1rono", "ikura-hamu"]
   }
@@ -69,7 +70,7 @@ locals {
       maintainers = ["itt828", "H1rono"]
     }
     "h24s_18" = {
-      members     = ["shushuya0210", "mumumu6"]
+      members     = ["shushuya0210", "mumumu6", "stamtam", "alcedo-taku"]
       maintainers = ["Takeno-hito", "aya-se"]
     }
     "h24s_21" = {

--- a/members.tf
+++ b/members.tf
@@ -5,6 +5,7 @@ locals {
     "abap34",         # abap34
     "Aketami23",      # aketami
     "Akira-256",      # Akira_256
+    "alcedo-taku",    # wakky
     "alex3333python", # alex_python
     "alter334",       # Alt--er
     "AlteraKlam",     # Alietty
@@ -103,6 +104,7 @@ locals {
     "Sotatsu57",       # Sotatsu
     "soucy-745",       # soucy
     "SSlime-s",        # SSLime
+    "stamtam",         # stam
     "sumirinn",        # sumirin
     "Synori",          # Synori
     # "Takeno-hito", # Takeno_hito admin


### PR DESCRIPTION
# traP-jp members Pull Request

## この変更の目的

<!--例:
ハッカソンのため
プロジェクトにメンバーを追加するため
-->

## GitHub IDとtraQ IDの対応

<!--例:
| GitHub ID | traQ ID |
| --------- | ------- |
| @ikura-hamu | ikura-hamu |
| @H1rono | H1rono_K |
-->

| GitHub ID | traQ ID |
| --------- | ------- |
|  @stamtam |  stam   |
|  @alcedo-taku  | wakky |

## 備考

## 加えた変更で、IDにtypoが無いことを確認しましたか?

**typoした先が実在するIDだった場合、無関係な人にtraP-jpへの招待が飛ぶなどの可能性があります。**

- [x] 確認した
