### PR TITLE
チーム33とチーム15

### DIFF
--- a/hackathon/h24s.tf
+++ b/hackathon/h24s.tf
@@ -29,7 +29,8 @@ locals {
       "Pentakon26", "pippi0057", "pirosiki197", "PL-38", "Pugma", "reiroop", "riku6174", "Series-205",
       "Synori", "trasta298", "ultsaza", "zer0-star", "aya-se", "shushuya0210", "mumumu6",
       "ZOI-dayo", "yuhima03", "cp-20", "AlteraKlam", "Propromp", "ynta-3", "shibutomo", "Silent-Clubstep", "comavius",
-      "stamtam", "alcedo-taku", "ramdos0207", "anko9801", "dye8128", "kavos113", "superharuma"
+      "stamtam", "alcedo-taku", "ramdos0207", "anko9801", "dye8128", "kavos113", "superharuma",
+      "inutamago-dogegg", "katsudontech", "AstartetraP", "the-edible-pan"
     ]
     maintainers = ["Takeno-hito", "kaitoyama", "H1rono", "ikura-hamu"]
   }
@@ -57,6 +58,12 @@ locals {
       members = []
       maintainers = [
         "alex3333python", "eyerust", "Nattuki", "reiroop", "ultsaza", "zer0-star"
+      ]
+    }
+    "h24s_15" = {
+      members = []
+      maintainers = [
+        "inutamago-dogegg", "katsudontech", "AstartetraP", "the-edible-pan"
       ]
     }
     "h24s_16" = {

--- a/hackathon/h24s.tf
+++ b/hackathon/h24s.tf
@@ -29,7 +29,7 @@ locals {
       "Pentakon26", "pippi0057", "pirosiki197", "PL-38", "Pugma", "reiroop", "riku6174", "Series-205",
       "Synori", "trasta298", "ultsaza", "zer0-star", "aya-se", "shushuya0210", "mumumu6",
       "ZOI-dayo", "yuhima03", "cp-20", "AlteraKlam", "Propromp", "ynta-3", "shibutomo", "Silent-Clubstep", "comavius",
-      "stamtam", "alcedo-taku"
+      "stamtam", "alcedo-taku", "ramdos0207", "anko9801", "dye8128", "kavos113", "superharuma"
     ]
     maintainers = ["Takeno-hito", "kaitoyama", "H1rono", "ikura-hamu"]
   }
@@ -92,6 +92,13 @@ locals {
       members = []
       maintainers = [
         "blancnoir256", "kamecha", "karo1111111", "Kuh456", "mirin-mochigome", "YMAC-STICK"
+      ]
+    }
+
+    "h24s_33" = {
+      members = []
+      maintainers = [
+        "ramdos0207", "anko9801", "dye8128", "kavos113", "superharuma"
       ]
     }
   }

--- a/members.tf
+++ b/members.tf
@@ -9,6 +9,7 @@ locals {
     "alex3333python", # alex_python
     "alter334",       # Alt--er
     "AlteraKlam",     # Alietty
+    "anko9801",       # anko
     "Apple000001",    # Apple
     "aster34",        # Aster
     "aya-se",         # aya_se
@@ -19,6 +20,7 @@ locals {
     "cobalt1024",     # cobalt
     "comavius",       # comavius
     "cp-20",          # cp20
+    "dye8128",        # Dye
     "emura0",         # emura
     "eran1515",       # Eran
     "eyerust",        # michadaniel
@@ -48,6 +50,7 @@ locals {
     "kamecha",         # kamecha
     "kanibaku",        # kanibaku8
     "karo1111111",     # karo
+    "kavos113",        # Kavos
     "Kein1048596",     # Kein
     "kenken714",       # kenken
     "kisepichu",       # tqk
@@ -106,6 +109,7 @@ locals {
     "SSlime-s",        # SSLime
     "stamtam",         # stam
     "sumirinn",        # sumirin
+    "superharuma",     # haruma
     "Synori",          # Synori
     # "Takeno-hito", # Takeno_hito admin
     "taxfree-python", # tax_free

--- a/members.tf
+++ b/members.tf
@@ -11,6 +11,7 @@ locals {
     "AlteraKlam",     # Alietty
     "anko9801",       # anko
     "Apple000001",    # Apple
+    "AstartetraP",    # Astarte
     "aster34",        # Aster
     "aya-se",         # aya_se
     "Ayaka-mogumogu", # mogumogu1515
@@ -50,6 +51,7 @@ locals {
     "kamecha",         # kamecha
     "kanibaku",        # kanibaku8
     "karo1111111",     # karo
+    "katsudontech",    # katsudon
     "kavos113",        # Kavos
     "Kein1048596",     # Kein
     "kenken714",       # kenken
@@ -113,6 +115,7 @@ locals {
     "Synori",          # Synori
     # "Takeno-hito", # Takeno_hito admin
     "taxfree-python", # tax_free
+    "the-edible-pan", # the_edible_pan
     "Thunder32768",   # Cd_48
     "tkr-555",        # tkr_d_555
     "tobuhitodesu",   # tobuhitodesu


### PR DESCRIPTION
# traP-jp members Pull Request

## この変更の目的

<!--例:
ハッカソンのため
プロジェクトにメンバーを追加するため
-->

## GitHub IDとtraQ IDの対応

<!--例:
| GitHub ID | traQ ID |
| --------- | ------- |
| @ikura-hamu | ikura-hamu |
| @H1rono | H1rono_K |
-->

33

| traQ ID | GitHub ID |
|---|---|
| ramdos | ramdos0207 |
| anko | anko9801 |
| Dye | dye8128 |
| Kavos | kavos113 |
| haruma | superharuma |

15

| traQ ID | GitHub ID |
|---|---|
| inutamago_dogegg | inutamago-dogegg |
| katsudon | katsudontech |
| Astarte | AstartetraP |
| the_edible_pan | the-edible-pan |

## 備考

## 加えた変更で、IDにtypoが無いことを確認しましたか?

**typoした先が実在するIDだった場合、無関係な人にtraP-jpへの招待が飛ぶなどの可能性があります。**

- [ ] 確認した
