### PR TITLE
Add Au294 to h24s.tf and members.tf

### DIFF
--- a/hackathon/h24s.tf
+++ b/hackathon/h24s.tf
@@ -23,7 +23,7 @@ locals {
   h24s_parent = {
     members = [
       "alex3333python", "alter334", "aster34", "ayanakm", "blancnoir256", "ErrorSyntax1",
-      "Futadaruma", "eyerust", "H1rono", "hatchch", "hyde616", "itt828", "jippo-m", "kamecha",
+      "Futadaruma", "eyerust", "hatchch", "Hyde616", "itt828", "jippo-m", "kamecha",
       "karo1111111", "kn-tech", "Kuh456", "Liscome", "Luftalian", "Luke256", "mathsuky", "mehm8128",
       "motoki317", "mtaku3", "nagaeki", "Nattuki", "nokhnaton", "noya2ruler", "ogu-kazemiya",
       "Pentakon26", "pippi0057", "pirosiki197", "PL-38", "Pugma", "reiroop", "riku6174", "Series-205",
@@ -40,7 +40,7 @@ locals {
     "h24s_04" = {
       members = []
       maintainers = [
-        "alter334", "hyde616", "kn-tech", "mehm8128", "noya2ruler"
+        "alter334", "Hyde616", "kn-tech", "mehm8128", "noya2ruler"
       ]
     }
     "h24s_10" = {

--- a/hackathon/h24s.tf
+++ b/hackathon/h24s.tf
@@ -31,7 +31,7 @@ locals {
       "ZOI-dayo", "YuHima03", "cp-20", "AlteraKlam", "Propromp", "ynta-3", "shibutomo", "Silent-Clubstep", "comavius",
       "stamtam", "wakky-alcedo", "ramdos0207", "anko9801", "dye8128", "kavos113", "superharuma",
       "inutamago-dogegg", "katsudontech", "AstartetraP", "the-edible-pan", "Rozelin-dc", "shota973",
-      "Sotatsu57", "kisepichu", "Nzt3-gh"
+      "Sotatsu57", "kisepichu", "Nzt3-gh", "Au294"
     ]
     maintainers = ["Takeno-hito", "kaitoyama", "H1rono", "ikura-hamu"]
   }
@@ -64,7 +64,7 @@ locals {
     "h24s_15" = {
       members = []
       maintainers = [
-        "inutamago-dogegg", "katsudontech", "AstartetraP", "the-edible-pan"
+        "inutamago-dogegg", "katsudontech", "AstartetraP", "the-edible-pan", "Au294"
       ]
     }
     "h24s_16" = {

--- a/members.tf
+++ b/members.tf
@@ -13,6 +13,7 @@ locals {
     "Apple000001",    # Apple
     "AstartetraP",    # Astarte
     "aster34",        # Aster
+    "Au294",          # Au2942
     "aya-se",         # aya_se
     "Ayaka-mogumogu", # mogumogu1515
     "ayanakm",        # ayana

--- a/members.tf
+++ b/members.tf
@@ -38,7 +38,7 @@ locals {
     "hijiki51",    # hijiki51
     "hinamas2004", # hinamas2004
     "Hueter57",    # Hueter
-    "hyde616",     # Hyde_616
+    "Hyde616",     # Hyde_616
     "iChemy",      # iChemy
     # "ikura-hamu", # ikura-hamu admin
     "Imperi13",         # Imperi


### PR DESCRIPTION
# traP-jp members Pull Request

## この変更の目的

<!--例:
ハッカソンのため
プロジェクトにメンバーを追加するため
-->
メンバーを追加するため

## GitHub IDとtraQ IDの対応

<!--例:
| GitHub ID | traQ ID |
| --------- | ------- |
| @ikura-hamu | ikura-hamu |
| @H1rono | H1rono_K |
-->

| GitHub ID | traQ ID |
| --------- | ------- |
| Au294 |@Au2942 |
|           |         |

## 備考

## 加えた変更で、IDにtypoが無いことを確認しましたか?

**typoした先が実在するIDだった場合、無関係な人にtraP-jpへの招待が飛ぶなどの可能性があります。**

- [x] 確認した
