### PR TITLE
:sparkles: GitHub Actionsでterraform fmtを実行してコミットする

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -38,6 +38,8 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -48,7 +50,17 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: Terraform fmt
-        run: terraform fmt -check -diff -recursive .
+        id: fmt
+        run: terraform fmt -recursive .
+
+      - name: Commit changes
+        if: steps.fmt.outputs.stdout != ''
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add .
+          git commit -m '[CI] terraform fmt'
+          git push
 
   plan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# traP-jp members Pull Request

## この変更の目的

terraformをインストールしてもらって手元で`terraform fmt`してもらうのは大変なので、CIでやる

<!--例:
ハッカソンのため
プロジェクトにメンバーを追加するため
-->

## GitHub IDとtraQ IDの対応

<!--例:
| GitHub ID | traQ ID |
| --------- | ------- |
| @ikura-hamu | ikura-hamu |
| @H1rono | H1rono_K |
-->

## 備考

## 加えた変更で、IDにtypoが無いことを確認しましたか?

**typoした先が実在するIDだった場合、無関係な人にtraP-jpへの招待が飛ぶなどの可能性があります。**

- [ ] 確認した
